### PR TITLE
feat: add client synchronization endpoint

### DIFF
--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
@@ -64,4 +64,30 @@ public class ClientsController(ICommandMediator commandMediator, IQueryMediator 
 
         return BadRequest("Error while tried created client.");
     }
+
+    /// <summary>
+    /// Synchronizes a client in the realm.
+    /// </summary>
+    /// <returns>
+    /// A 200 OK status code along with the list of clients if the operation is successful;
+    /// otherwise, a 400 Bad Request status code with an error message, or a 500 Internal Server Error status code if something goes wrong.
+    /// </returns>
+    /// <param name="targetTenant">The body related to the tenant that will be synchronized.</param>
+    /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken"/> used to observe cancellation requests for the operation.</param>
+    [HttpPost("{targetTenant}/sync")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [RequiredRole("Feijuca.ApiWriter")]
+    public async Task<IActionResult> SyncClient([FromRoute] string targetTenant, CancellationToken cancellationToken)
+    {
+        var result = await commandMediator.SendAsync(new SyncClientCommand(targetTenant), cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            return Created();
+        }
+
+        return BadRequest("Error while tried created client.");
+    }
 }

--- a/src/Api/Feijuca.Auth.Api/Program.cs
+++ b/src/Api/Feijuca.Auth.Api/Program.cs
@@ -53,7 +53,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseTenantMiddleware();
 app.UseMiddleware<ConfigValidationMiddleware>();
-app.UseHealthCheckers();
+app.UseHealthCheckers(keycloakSettings);
 app.UseHttpsRedirection();
 app.UseSwagger();
 app.UseSwaggerUI(c =>

--- a/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommand.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommand.cs
@@ -1,0 +1,6 @@
+﻿using Feijuca.Auth.Models;
+using LiteBus.Commands.Abstractions;
+
+namespace Feijuca.Auth.Application.Commands.Client;
+
+public record SyncClientCommand(string TargetTenant) : ICommand<Result>;

--- a/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommandHandler.cs
@@ -1,0 +1,69 @@
+﻿using Feijuca.Auth.Common;
+using Feijuca.Auth.Domain.Entities;
+using Feijuca.Auth.Domain.Interfaces;
+using Feijuca.Auth.Models;
+using Feijuca.Auth.Providers;
+using LiteBus.Commands.Abstractions;
+
+namespace Feijuca.Auth.Application.Commands.Client;
+
+public class SyncClientCommandHandler(ITenantProvider tenantProvider,
+    IClientRepository clientRepository,
+    IClientRoleRepository clientRoleRepository,
+    IGroupRolesRepository groupRolesRepository,
+    IGroupRepository groupRepository) : ICommandHandler<SyncClientCommand, Result>
+{
+    public async Task<Result> HandleAsync(SyncClientCommand request, CancellationToken cancellationToken = default)
+    {
+        var originTenant = tenantProvider.Tenant.Name;
+        var originClients = await clientRepository.GetClientsAsync(originTenant, cancellationToken);
+
+        var adminGroupResult = await groupRepository.GetGroupByNameAsync(Constants.AdminGroupName, request.TargetTenant, cancellationToken);
+        var adminGroupId = adminGroupResult.Data!.FirstOrDefault()!.Id;
+
+        var clientsInTargetRealm = (await clientRepository.GetClientsAsync(request.TargetTenant, cancellationToken)).Data;
+
+        foreach (var client in originClients?.Data ?? [])
+        {
+            if (!clientsInTargetRealm.Any(c => c.ClientId == client.ClientId))
+            {
+                var clientId = (await clientRepository.CreateClientAsync(client, request.TargetTenant, cancellationToken)).Data;
+
+                await AssociatedRulesToTheClientAsync(request.TargetTenant, originTenant, client, clientId, cancellationToken);
+                await AssociateClientRulesToTheGroupAsync(request.TargetTenant, adminGroupId!, clientId, cancellationToken);
+            }
+        }
+
+        return Result.Success();
+    }
+
+    private async Task AssociatedRulesToTheClientAsync(string targetTenant, string originTenant, ClientEntity client, string clientId, CancellationToken cancellationToken)
+    {
+        var originClientRoles = await clientRoleRepository.GetRolesForClientAsync(client.Id, originTenant, cancellationToken);
+
+        foreach (var clientRole in originClientRoles.Data)
+        {
+            await clientRoleRepository.AddClientRoleAsync(clientId,
+                clientRole.Name,
+                clientRole?.Description ?? "",
+                targetTenant,
+                cancellationToken);
+        }
+    }
+
+    private async Task AssociateClientRulesToTheGroupAsync(string targetTenant, string adminGroupId, string clientId, CancellationToken cancellationToken)
+    {
+        var targetClientRulesAdded = await clientRoleRepository.GetRolesForClientAsync(clientId, targetTenant, cancellationToken);
+
+        foreach (var targetClientRuleAdded in targetClientRulesAdded.Data)
+        {
+            await groupRolesRepository.AddClientRoleToGroupAsync(adminGroupId,
+                clientId,
+                targetClientRuleAdded.Id,
+                targetClientRuleAdded.Name,
+                targetTenant,
+                cancellationToken);
+        }
+    }
+
+}

--- a/src/Api/Feijuca.Auth.Application/Commands/Config/AddOrUpdateConfigCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Config/AddOrUpdateConfigCommandHandler.cs
@@ -5,7 +5,6 @@ using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using LiteBus.Commands.Abstractions;
-using Feijuca.Auth.Models;
 
 namespace Feijuca.Auth.Application.Commands.Config
 {

--- a/src/Api/Feijuca.Auth.Application/Commands/User/LoginCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/User/LoginCommandHandler.cs
@@ -4,7 +4,6 @@ using Feijuca.Auth.Http.Responses;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using LiteBus.Commands.Abstractions;
-using Feijuca.Auth.Models;
 
 namespace Feijuca.Auth.Application.Commands.User
 {

--- a/src/Api/Feijuca.Auth.Application/Feijuca.Auth.Application.csproj
+++ b/src/Api/Feijuca.Auth.Application/Feijuca.Auth.Application.csproj
@@ -19,7 +19,6 @@
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="LiteBus.Commands.Extensions.MicrosoftDependencyInjection" Version="3.1.0" />
 		<PackageReference Include="LiteBus.Queries.Extensions.MicrosoftDependencyInjection" Version="3.1.0" />
-		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Serilog" Version="4.4.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/src/Api/Feijuca.Auth.Domain/Interfaces/IGroupRepository.cs
+++ b/src/Api/Feijuca.Auth.Domain/Interfaces/IGroupRepository.cs
@@ -7,7 +7,7 @@ namespace Feijuca.Auth.Domain.Interfaces
     public interface IGroupRepository : IBaseRepository
     {
         Task<Result<IEnumerable<Group>>> GetAllAsync(CancellationToken cancellationToken);
-        Task<Result<IEnumerable<Group>>> GetGroupByNameAsync(string? groupName, CancellationToken cancellationToken);
+        Task<Result<IEnumerable<Group>>> GetGroupByNameAsync(string? groupName, string? tenant, CancellationToken cancellationToken);
         Task<Result<string>> CreateAsync(string name, string tenant, Dictionary<string, string[]> attributes, CancellationToken cancellationToken);
         Task<Result> UpdateAsync(Group group, CancellationToken cancellationToken);
         Task<Result> DeleteAsync(string id, CancellationToken cancellationToken);

--- a/src/Api/Feijuca.Auth.Infra.CrossCutting/Extensions/HealthCheckersExtensions.cs
+++ b/src/Api/Feijuca.Auth.Infra.CrossCutting/Extensions/HealthCheckersExtensions.cs
@@ -29,13 +29,16 @@ namespace Feijuca.Auth.Infra.CrossCutting.Extensions
             return services;
         }
 
-        public static void UseHealthCheckers(this IApplicationBuilder app)
+        public static void UseHealthCheckers(this IApplicationBuilder app, KeycloakSettings keycloakSettings)
         {
-            app.UseHealthChecks("/health", new HealthCheckOptions
+            if (keycloakSettings != null)
             {
-                Predicate = _ => true,
-                ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-            });
+                app.UseHealthChecks("/health", new HealthCheckOptions
+                {
+                    Predicate = _ => true,
+                    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                });
+            }
         }
     }
 }

--- a/src/Api/Feijuca.Auth.Infra.Data/Repositories/GroupRepository.cs
+++ b/src/Api/Feijuca.Auth.Infra.Data/Repositories/GroupRepository.cs
@@ -46,6 +46,7 @@ namespace Feijuca.Auth.Infra.Data.Repositories
 
         public async Task<Result<IEnumerable<Group>>> GetGroupByNameAsync(
             string? groupName,
+            string? tenant,
             CancellationToken cancellationToken)
         {
             var tokenDetailsResult = await _authRepository.GetAccessTokenAsync(cancellationToken);
@@ -58,7 +59,7 @@ namespace Feijuca.Auth.Infra.Data.Repositories
             var url = httpClient.BaseAddress
                 .AppendPathSegment("admin")
                 .AppendPathSegment("realms")
-                .AppendPathSegment(_tenantProvider.Tenant.Name)
+                .AppendPathSegment(tenant ?? _tenantProvider.Tenant.Name)
                 .AppendPathSegment("groups");
 
             if (!string.IsNullOrWhiteSpace(groupName))

--- a/src/Api/Feijuca.Auth.Infra.Data/Repositories/RealmRepository.cs
+++ b/src/Api/Feijuca.Auth.Infra.Data/Repositories/RealmRepository.cs
@@ -3,7 +3,6 @@ using Feijuca.Auth.Domain.Entities;
 using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Flurl;
-using Feijuca.Auth.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Net.Http.Json;

--- a/tests/Feijuca.Auth.UnitTests/Command/GroupRoles/RemoveRoleFromGroupCommandHandlerTests.cs
+++ b/tests/Feijuca.Auth.UnitTests/Command/GroupRoles/RemoveRoleFromGroupCommandHandlerTests.cs
@@ -1,13 +1,12 @@
 ﻿using AutoFixture;
 using Feijuca.Auth.Application.Commands.GroupRoles;
 using Feijuca.Auth.Common.Errors;
-using Feijuca.Auth.Models;
 using Feijuca.Auth.Domain.Entities;
 using Feijuca.Auth.Domain.Interfaces;
+using Feijuca.Auth.Models;
+using Feijuca.Auth.Providers;
 using FluentAssertions;
 using Moq;
-using Feijuca.Auth.Providers;
-using Feijuca.Auth.Models;
 
 namespace Feijuca.Auth.Api.UnitTests.Command.GroupRoles
 {

--- a/tests/Feijuca.Auth.UnitTests/Command/GroupUser/AddUserToGroupCommandHandlerTests.cs
+++ b/tests/Feijuca.Auth.UnitTests/Command/GroupUser/AddUserToGroupCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using FluentAssertions;
-using Feijuca.Auth.Models;
 using Moq;
 
 namespace Feijuca.Auth.Api.UnitTests.Command.GroupUser

--- a/tests/Feijuca.Auth.UnitTests/Command/Groups/CreateGroupCommandHandlerTests.cs
+++ b/tests/Feijuca.Auth.UnitTests/Command/Groups/CreateGroupCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using FluentAssertions;
-using Feijuca.Auth.Models;
 using Moq;
 
 namespace Feijuca.Auth.Api.UnitTests.Command.Groups

--- a/tests/Feijuca.Auth.UnitTests/Command/Roles/AddClientRoleCommandHandlerTests.cs
+++ b/tests/Feijuca.Auth.UnitTests/Command/Roles/AddClientRoleCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using FluentAssertions;
-using Feijuca.Auth.Models;
 using Moq;
 
 namespace Feijuca.Auth.Api.UnitTests.Command.Roles

--- a/tests/Feijuca.Auth.UnitTests/Queries/Clients/GetAllClientsQueryHandlerTests.cs
+++ b/tests/Feijuca.Auth.UnitTests/Queries/Clients/GetAllClientsQueryHandlerTests.cs
@@ -6,7 +6,6 @@ using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using FluentAssertions;
-using Feijuca.Auth.Models;
 using Moq;
 
 namespace Feijuca.Auth.Api.UnitTests.Queries.Clients

--- a/tests/Feijuca.Auth.UnitTests/Queries/Permissions/GetRolesQueryHandlerTests.cs
+++ b/tests/Feijuca.Auth.UnitTests/Queries/Permissions/GetRolesQueryHandlerTests.cs
@@ -6,7 +6,6 @@ using Feijuca.Auth.Domain.Interfaces;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using FluentAssertions;
-using Feijuca.Auth.Models;
 using Moq;
 
 namespace Feijuca.Auth.Api.UnitTests.Queries.Permissions


### PR DESCRIPTION
## Summary

Added a new endpoint to synchronize clients across tenants.

## Changes

- Added an endpoint to trigger client synchronization.
- Added logic to identify clients that are missing in the target tenant.
- Added missing clients to the target tenant.
- Synchronized client rules and group associations.
- Prevented duplicate clients from being created in the target tenant.

## Purpose

This allows clients to be synchronized between tenants while preserving their associated rules and group permissions.