### PR TITLE
Fix: calculate total pages in PagedResult

### DIFF
--- a/src/NuGet/Feijuca.Auth/Models/PagedResult.cs
+++ b/src/NuGet/Feijuca.Auth/Models/PagedResult.cs
@@ -6,7 +6,7 @@ public class PagedResult<T>
 
     public int PageNumber { get; set; }
     public int PageSize { get; set; }
-    public int TotalPages { get; set; }
+    public int TotalPages => (TotalResults + PageSize - 1) / PageSize;
     public int TotalResults { get; set; }
     public IEnumerable<T> Results { get; set; }
 }


### PR DESCRIPTION
Corrige o cálculo do campo TotalPages no PagedResult<T>.

Anteriormente, TotalPages era uma propriedade set, fazendo com que permanecesse com o valor padrão 0 quando não fosse preenchida explicitamente.

Agora o valor é calculado com base no TotalResults e PageSize