### PR TITLE
Feat/add sync roles

### DIFF
--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
@@ -79,7 +79,7 @@ public class ClientsController(ICommandMediator commandMediator, IQueryMediator 
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [RequiredRole("Feijuca.ApiWriter")]
-    public async Task<IActionResult> SyncClient([FromRoute] SyncClientRequest syncClientRequest, CancellationToken cancellationToken)
+    public async Task<IActionResult> SyncClient([FromBody] SyncClientRequest syncClientRequest, CancellationToken cancellationToken)
     {
         var result = await commandMediator.SendAsync(new SyncClientCommand(syncClientRequest), cancellationToken);
 

--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
@@ -72,16 +72,16 @@ public class ClientsController(ICommandMediator commandMediator, IQueryMediator 
     /// A 200 OK status code along with the list of clients if the operation is successful;
     /// otherwise, a 400 Bad Request status code with an error message, or a 500 Internal Server Error status code if something goes wrong.
     /// </returns>
-    /// <param name="targetTenant">The body related to the tenant that will be synchronized.</param>
+    /// <param name="syncClientRequest">The body related to the client that will be synchronized.</param>
     /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken"/> used to observe cancellation requests for the operation.</param>
     [HttpPost("{targetTenant}/sync")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [RequiredRole("Feijuca.ApiWriter")]
-    public async Task<IActionResult> SyncClient([FromRoute] string targetTenant, CancellationToken cancellationToken)
+    public async Task<IActionResult> SyncClient([FromRoute] SyncClientRequest syncClientRequest, CancellationToken cancellationToken)
     {
-        var result = await commandMediator.SendAsync(new SyncClientCommand(targetTenant), cancellationToken);
+        var result = await commandMediator.SendAsync(new SyncClientCommand(syncClientRequest), cancellationToken);
 
         if (result.IsSuccess)
         {

--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsController.cs
@@ -74,7 +74,7 @@ public class ClientsController(ICommandMediator commandMediator, IQueryMediator 
     /// </returns>
     /// <param name="syncClientRequest">The body related to the client that will be synchronized.</param>
     /// <param name="cancellationToken">A <see cref="T:System.Threading.CancellationToken"/> used to observe cancellation requests for the operation.</param>
-    [HttpPost("{targetTenant}/sync")]
+    [HttpPost("sync")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsRolesController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsRolesController.cs
@@ -65,5 +65,32 @@ namespace Feijuca.Auth.Api.Controllers
 
             return BadRequest(Result<string>.Failure(result.Error));
         }
+
+
+        /// <summary>
+        /// Synchronizes the roles of a client with the specified target tenant.
+        /// </summary>
+        /// <param name="targetTenant">The target tenant where the client roles will be synchronized.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
+        /// <returns>
+        /// A <see cref="StatusCodes.Status200OK"/> status code if the roles were successfully synchronized;
+        /// otherwise, a <see cref="StatusCodes.Status400BadRequest"/> status code containing the error details.
+        /// </returns>
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [RequiredRole("Feijuca.ApiWriter")]
+        public async Task<IActionResult> SyncClientRoles([FromBody] string targetTenant, CancellationToken cancellationToken)
+        {
+            var result = await commandMediator.SendAsync(new SyncClientRoleCommand(targetTenant), cancellationToken);
+
+            if (result.IsSuccess)
+            {
+                return Ok();
+            }
+
+            return BadRequest(Result<string>.Failure(result.Error));
+        }
     }
 }

--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsRolesController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsRolesController.cs
@@ -70,7 +70,7 @@ namespace Feijuca.Auth.Api.Controllers
         /// <summary>
         /// Synchronizes the roles of a client with the specified target tenant.
         /// </summary>
-        /// <param name="targetTenant">The target tenant where the client roles will be synchronized.</param>
+        /// <param name="syncRoleRequest">The request object containing the synchronization details.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
         /// <returns>
         /// A <see cref="StatusCodes.Status200OK"/> status code if the roles were successfully synchronized;
@@ -81,9 +81,9 @@ namespace Feijuca.Auth.Api.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [RequiredRole("Feijuca.ApiWriter")]
-        public async Task<IActionResult> SyncClientRoles([FromBody] string targetTenant, CancellationToken cancellationToken)
+        public async Task<IActionResult> SyncClientRoles([FromBody] SyncRoleRequest syncRoleRequest, CancellationToken cancellationToken)
         {
-            var result = await commandMediator.SendAsync(new SyncClientRoleCommand(targetTenant), cancellationToken);
+            var result = await commandMediator.SendAsync(new SyncClientRoleCommand(syncRoleRequest), cancellationToken);
 
             if (result.IsSuccess)
             {

--- a/src/Api/Feijuca.Auth.Api/Controllers/ClientsRolesController.cs
+++ b/src/Api/Feijuca.Auth.Api/Controllers/ClientsRolesController.cs
@@ -76,7 +76,7 @@ namespace Feijuca.Auth.Api.Controllers
         /// A <see cref="StatusCodes.Status200OK"/> status code if the roles were successfully synchronized;
         /// otherwise, a <see cref="StatusCodes.Status400BadRequest"/> status code containing the error details.
         /// </returns>
-        [HttpPost]
+        [HttpPost("sync")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommand.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommand.cs
@@ -1,6 +1,7 @@
-﻿using Feijuca.Auth.Models;
+﻿using Feijuca.Auth.Application.Requests.Client;
+using Feijuca.Auth.Models;
 using LiteBus.Commands.Abstractions;
 
 namespace Feijuca.Auth.Application.Commands.Client;
 
-public record SyncClientCommand(string TargetTenant) : ICommand<Result>;
+public record SyncClientCommand(SyncClientRequest SyncClientRequest) : ICommand<Result>;

--- a/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Feijuca.Auth.Common;
 using Feijuca.Auth.Domain.Entities;
 using Feijuca.Auth.Domain.Interfaces;
-using Feijuca.Auth.Http.Client;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using LiteBus.Commands.Abstractions;
@@ -10,7 +9,7 @@ namespace Feijuca.Auth.Application.Commands.Client;
 
 public class SyncClientCommandHandler(ITenantProvider tenantProvider,
     IClientRepository clientRepository,
-    IFeijucaAuthClient feijucaAuthClient,
+    IRealmRepository realmRepository,
     IClientRoleRepository clientRoleRepository,
     IGroupRolesRepository groupRolesRepository,
     IGroupRepository groupRepository) : ICommandHandler<SyncClientCommand, Result>
@@ -22,8 +21,7 @@ public class SyncClientCommandHandler(ITenantProvider tenantProvider,
 
         if (request.SyncClientRequest.AllTenants)
         {
-            var token = tenantProvider.GetToken();
-            var realms = (await feijucaAuthClient.GetRealmsAsync(token, cancellationToken)).Data;
+            var realms = await realmRepository.GetAllAsync(cancellationToken);
 
             targetTenants = realms.Select(r => r.Realm).Where(r => r != originTenant);
         }

--- a/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/Client/SyncClientCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Feijuca.Auth.Common;
 using Feijuca.Auth.Domain.Entities;
 using Feijuca.Auth.Domain.Interfaces;
+using Feijuca.Auth.Http.Client;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using LiteBus.Commands.Abstractions;
@@ -9,6 +10,7 @@ namespace Feijuca.Auth.Application.Commands.Client;
 
 public class SyncClientCommandHandler(ITenantProvider tenantProvider,
     IClientRepository clientRepository,
+    IFeijucaAuthClient feijucaAuthClient,
     IClientRoleRepository clientRoleRepository,
     IGroupRolesRepository groupRolesRepository,
     IGroupRepository groupRepository) : ICommandHandler<SyncClientCommand, Result>
@@ -16,21 +18,34 @@ public class SyncClientCommandHandler(ITenantProvider tenantProvider,
     public async Task<Result> HandleAsync(SyncClientCommand request, CancellationToken cancellationToken = default)
     {
         var originTenant = tenantProvider.Tenant.Name;
+        IEnumerable<string> targetTenants = request.SyncClientRequest.TargetTenant != null ? [request.SyncClientRequest.TargetTenant] : [];
+
+        if (request.SyncClientRequest.AllTenants)
+        {
+            var token = tenantProvider.GetToken();
+            var realms = (await feijucaAuthClient.GetRealmsAsync(token, cancellationToken)).Data;
+
+            targetTenants = realms.Select(r => r.Realm).Where(r => r != originTenant);
+        }
+
         var originClients = await clientRepository.GetClientsAsync(originTenant, cancellationToken);
 
-        var adminGroupResult = await groupRepository.GetGroupByNameAsync(Constants.AdminGroupName, request.TargetTenant, cancellationToken);
-        var adminGroupId = adminGroupResult.Data!.FirstOrDefault()!.Id;
-
-        var clientsInTargetRealm = (await clientRepository.GetClientsAsync(request.TargetTenant, cancellationToken)).Data;
-
-        foreach (var client in originClients?.Data ?? [])
+        foreach (var targetTenant in targetTenants)
         {
-            if (!clientsInTargetRealm.Any(c => c.ClientId == client.ClientId))
-            {
-                var clientId = (await clientRepository.CreateClientAsync(client, request.TargetTenant, cancellationToken)).Data;
+            var adminGroupResult = await groupRepository.GetGroupByNameAsync(Constants.AdminGroupName, targetTenant, cancellationToken);
+            var adminGroupId = adminGroupResult.Data!.FirstOrDefault()!.Id;
 
-                await AssociatedRulesToTheClientAsync(request.TargetTenant, originTenant, client, clientId, cancellationToken);
-                await AssociateClientRulesToTheGroupAsync(request.TargetTenant, adminGroupId!, clientId, cancellationToken);
+            var clientsInTargetRealm = (await clientRepository.GetClientsAsync(targetTenant, cancellationToken)).Data;
+
+            foreach (var client in originClients?.Data ?? [])
+            {
+                if (!clientsInTargetRealm.Any(c => c.ClientId == client.ClientId))
+                {
+                    var clientId = (await clientRepository.CreateClientAsync(client, targetTenant, cancellationToken)).Data;
+
+                    await AssociatedRulesToTheClientAsync(targetTenant, originTenant, client, clientId, cancellationToken);
+                    await AssociateClientRulesToTheGroupAsync(targetTenant, adminGroupId!, clientId, cancellationToken);
+                }
             }
         }
 

--- a/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommand.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommand.cs
@@ -1,0 +1,6 @@
+﻿using Feijuca.Auth.Models;
+using LiteBus.Commands.Abstractions;
+
+namespace Feijuca.Auth.Application.Commands.ClientRole;
+
+public record SyncClientRoleCommand(string TargetTenant) : ICommand<Result<bool>>;

--- a/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommand.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommand.cs
@@ -1,6 +1,7 @@
-﻿using Feijuca.Auth.Models;
+﻿using Feijuca.Auth.Application.Requests.Role;
+using Feijuca.Auth.Models;
 using LiteBus.Commands.Abstractions;
 
 namespace Feijuca.Auth.Application.Commands.ClientRole;
 
-public record SyncClientRoleCommand(string TargetTenant) : ICommand<Result<bool>>;
+public record SyncClientRoleCommand(SyncRoleRequest SyncRoleRequest) : ICommand<Result<bool>>;

--- a/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommandHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Feijuca.Auth.Domain.Interfaces;
-using Feijuca.Auth.Http.Client;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using LiteBus.Commands.Abstractions;
@@ -10,23 +9,22 @@ namespace Feijuca.Auth.Application.Commands.ClientRole;
 public class SyncClientRoleCommandHandler(ITenantProvider tenantProvider,
     IClientRepository clientRepository,
     IClientRoleRepository clientRoleRepository,
-    IFeijucaAuthClient feijucaAuthClient) : ICommandHandler<SyncClientRoleCommand, Result<bool>>
+    IRealmRepository realmRepository) : ICommandHandler<SyncClientRoleCommand, Result<bool>>
 {
     public async Task<Result<bool>> HandleAsync(SyncClientRoleCommand request, CancellationToken cancellationToken = default)
     {
+        var originTenant = tenantProvider.Tenant.Name;
         IEnumerable<string> targetTenants = request.SyncRoleRequest.TargetTenant != null ? [request.SyncRoleRequest.TargetTenant] : [];
 
         if (request.SyncRoleRequest.AllTenants)
         {
-            var token = tenantProvider.GetToken();
-            var realms = (await feijucaAuthClient.GetRealmsAsync(token, cancellationToken)).Data;
+            var realms = await realmRepository.GetAllAsync(cancellationToken);
 
-            targetTenants = realms.Select(r => r.Realm).Where(r => r != tenantProvider.Tenant.Name);
+            targetTenants = realms.Select(r => r.Realm).Where(r => r != originTenant);
         }
 
         foreach (var targetTenant in targetTenants)
         {
-            var originTenant = tenantProvider.Tenant.Name;
             var originClients = await clientRepository.GetClientsAsync(originTenant, cancellationToken);
 
             var clientsInTargetRealm = (await clientRepository.GetClientsAsync(targetTenant, cancellationToken)).Data;

--- a/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommandHandler.cs
@@ -1,39 +1,55 @@
 ﻿using Feijuca.Auth.Domain.Interfaces;
+using Feijuca.Auth.Http.Client;
 using Feijuca.Auth.Models;
 using Feijuca.Auth.Providers;
 using LiteBus.Commands.Abstractions;
+using MongoDB.Driver;
 
 namespace Feijuca.Auth.Application.Commands.ClientRole;
 
 public class SyncClientRoleCommandHandler(ITenantProvider tenantProvider,
     IClientRepository clientRepository,
-    IClientRoleRepository clientRoleRepository) : ICommandHandler<SyncClientRoleCommand, Result<bool>>
+    IClientRoleRepository clientRoleRepository,
+    IFeijucaAuthClient feijucaAuthClient) : ICommandHandler<SyncClientRoleCommand, Result<bool>>
 {
     public async Task<Result<bool>> HandleAsync(SyncClientRoleCommand request, CancellationToken cancellationToken = default)
     {
-        var originTenant = tenantProvider.Tenant.Name;
-        var originClients = await clientRepository.GetClientsAsync(originTenant, cancellationToken);
+        IEnumerable<string> targetTenants = request.SyncRoleRequest.TargetTenant != null ? [request.SyncRoleRequest.TargetTenant] : [];
 
-        var clientsInTargetRealm = (await clientRepository.GetClientsAsync(request.TargetTenant, cancellationToken)).Data;
-
-        foreach (var originClient in originClients?.Data ?? [])
+        if (request.SyncRoleRequest.AllTenants)
         {
-            var originClientRoles = (await clientRoleRepository.GetRolesForClientAsync(originClient.Id, originTenant, cancellationToken)).Data;
+            var token = tenantProvider.GetToken();
+            var realms = (await feijucaAuthClient.GetRealmsAsync(token, cancellationToken)).Data;
 
-            if (clientsInTargetRealm.Any(c => c.ClientId == originClient.ClientId))
+            targetTenants = realms.Select(r => r.Realm).Where(r => r != tenantProvider.Tenant.Name);
+        }
+
+        foreach (var targetTenant in targetTenants)
+        {
+            var originTenant = tenantProvider.Tenant.Name;
+            var originClients = await clientRepository.GetClientsAsync(originTenant, cancellationToken);
+
+            var clientsInTargetRealm = (await clientRepository.GetClientsAsync(targetTenant, cancellationToken)).Data;
+
+            foreach (var originClient in originClients?.Data ?? [])
             {
-                var targetClient = clientsInTargetRealm.First(c => c.ClientId == originClient.ClientId);
-                var targetClientRoles = (await clientRoleRepository.GetRolesForClientAsync(targetClient.Id, request.TargetTenant, cancellationToken)).Data;
+                var originClientRoles = (await clientRoleRepository.GetRolesForClientAsync(originClient.Id, originTenant, cancellationToken)).Data;
 
-                foreach (var originClientRole in originClientRoles ?? [])
+                if (clientsInTargetRealm.Any(c => c.ClientId == originClient.ClientId))
                 {
-                    if (!targetClientRoles.Any(r => r.Name == originClientRole.Name))
+                    var targetClient = clientsInTargetRealm.First(c => c.ClientId == originClient.ClientId);
+                    var targetClientRoles = (await clientRoleRepository.GetRolesForClientAsync(targetClient.Id, targetTenant, cancellationToken)).Data;
+
+                    foreach (var originClientRole in originClientRoles ?? [])
                     {
-                        await clientRoleRepository.AddClientRoleAsync(targetClient.Id,
-                                originClientRole.Name,
-                                originClientRole?.Description ?? "",
-                                request.TargetTenant,
-                                cancellationToken);
+                        if (!targetClientRoles.Any(r => r.Name == originClientRole.Name))
+                        {
+                            await clientRoleRepository.AddClientRoleAsync(targetClient.Id,
+                                    originClientRole.Name,
+                                    originClientRole?.Description ?? "",
+                                    targetTenant,
+                                    cancellationToken);
+                        }
                     }
                 }
             }

--- a/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Commands/ClientRole/SyncClientRoleCommandHandler.cs
@@ -1,0 +1,44 @@
+﻿using Feijuca.Auth.Domain.Interfaces;
+using Feijuca.Auth.Models;
+using Feijuca.Auth.Providers;
+using LiteBus.Commands.Abstractions;
+
+namespace Feijuca.Auth.Application.Commands.ClientRole;
+
+public class SyncClientRoleCommandHandler(ITenantProvider tenantProvider,
+    IClientRepository clientRepository,
+    IClientRoleRepository clientRoleRepository) : ICommandHandler<SyncClientRoleCommand, Result<bool>>
+{
+    public async Task<Result<bool>> HandleAsync(SyncClientRoleCommand request, CancellationToken cancellationToken = default)
+    {
+        var originTenant = tenantProvider.Tenant.Name;
+        var originClients = await clientRepository.GetClientsAsync(originTenant, cancellationToken);
+
+        var clientsInTargetRealm = (await clientRepository.GetClientsAsync(request.TargetTenant, cancellationToken)).Data;
+
+        foreach (var originClient in originClients?.Data ?? [])
+        {
+            var originClientRoles = (await clientRoleRepository.GetRolesForClientAsync(originClient.Id, originTenant, cancellationToken)).Data;
+
+            if (clientsInTargetRealm.Any(c => c.ClientId == originClient.ClientId))
+            {
+                var targetClient = clientsInTargetRealm.First(c => c.ClientId == originClient.ClientId);
+                var targetClientRoles = (await clientRoleRepository.GetRolesForClientAsync(targetClient.Id, request.TargetTenant, cancellationToken)).Data;
+
+                foreach (var originClientRole in originClientRoles ?? [])
+                {
+                    if (!targetClientRoles.Any(r => r.Name == originClientRole.Name))
+                    {
+                        await clientRoleRepository.AddClientRoleAsync(targetClient.Id,
+                                originClientRole.Name,
+                                originClientRole?.Description ?? "",
+                                request.TargetTenant,
+                                cancellationToken);
+                    }
+                }
+            }
+        }
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/src/Api/Feijuca.Auth.Application/Requests/Client/SyncClientRequest.cs
+++ b/src/Api/Feijuca.Auth.Application/Requests/Client/SyncClientRequest.cs
@@ -1,3 +1,3 @@
 ﻿namespace Feijuca.Auth.Application.Requests.Client;
 
-public record SyncClientRequest(string? TargetTenant, bool AllTenants = false);
+public record SyncClientRequest(string? TargetTenant, bool AllTenants);

--- a/src/Api/Feijuca.Auth.Application/Requests/Client/SyncClientRequest.cs
+++ b/src/Api/Feijuca.Auth.Application/Requests/Client/SyncClientRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace Feijuca.Auth.Application.Requests.Client;
+
+public record SyncClientRequest(string? TargetTenant, bool AllTenants = false);

--- a/src/Api/Feijuca.Auth.Application/Requests/Role/SyncRoleRequest.cs
+++ b/src/Api/Feijuca.Auth.Application/Requests/Role/SyncRoleRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace Feijuca.Auth.Application.Requests.Role;
+
+public record SyncRoleRequest(string? TargetTenant, bool AllTenants = false);

--- a/src/Api/Feijuca.Auth.Application/Requests/Role/SyncRoleRequest.cs
+++ b/src/Api/Feijuca.Auth.Application/Requests/Role/SyncRoleRequest.cs
@@ -1,3 +1,3 @@
 ﻿namespace Feijuca.Auth.Application.Requests.Role;
 
-public record SyncRoleRequest(string? TargetTenant, bool AllTenants = false);
+public record SyncRoleRequest(string? TargetTenant, bool AllTenants);


### PR DESCRIPTION
## Summary

Refactors and extends client and client-role synchronization to support both specific-tenant and all-tenant scenarios.

### Changes

* Refactors `SyncClientCommand` to receive `SyncClientRequest`.
* Adds support for synchronizing clients across all available tenants.
* Improves the synchronization flow by avoiding repeated retrieval of the source tenant inside loops.
* Updates `SyncClientRoles` to receive `SyncRoleRequest`.
* Adds support for synchronizing client roles across all tenants through the `AllTenants` flag.
* Adds `SyncClientRoleCommand` and `SyncClientRoleCommandHandler` to handle client-role synchronization.
* Adds the `SyncClientRoles` endpoint to `ClientsRolesController`.
* Adds request records to standardize synchronization requests.
* Maintains support for synchronization targeting a specific tenant.
* Adds XML documentation and appropriate HTTP response annotations to the new endpoint.

### Result

The synchronization flow is now more consistent and flexible, allowing clients and their roles to be synchronized either to a specific tenant or across all available tenants.
