### PR TITLE
Feat/expondoendpoints

### DIFF
--- a/src/NuGet/Feijuca.Auth/Errors/FeijucaErrors.cs
+++ b/src/NuGet/Feijuca.Auth/Errors/FeijucaErrors.cs
@@ -14,4 +14,6 @@ public static class FeijucaErrors
     public static readonly Error AddUserToGroupError = new("AddUserToGroupError", "An error occured while to add user in group");
     public static readonly Error UpdateGroupNameError = new("UpdateGroupNameError", "An error occured while updating group name.");
     public static readonly Error ReplicateRealmError = new("ReplicateRealmError", "An error occured while replicating realm.");
+    public static readonly Error RemoveUsersFromGroupError = new("RemoveUsersFromGroupError", "An error occurred while removing users from group.");
+    public static readonly Error CreateRealmError = new("CreateRealmError", "An error occurred while creating realm.");
 }

--- a/src/NuGet/Feijuca.Auth/Http/BaseHttp/BaseHttpClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/BaseHttp/BaseHttpClient.cs
@@ -62,6 +62,32 @@ public class BaseHttpClient(HttpClient httpClient)
         return result!;
     }
 
+    protected async Task<TResponse> DeleteAsync<TRequest, TResponse>(
+    string path,
+    TRequest request,
+    CancellationToken cancellationToken)
+    where TRequest : class
+    {
+        var url = _httpClient.BaseAddress!.AppendPathSegment(path);
+
+        string json = JsonConvert.SerializeObject(request);
+
+        StringContent bodyContent = new(json, Encoding.UTF8, "application/json");
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Delete, url)
+        {
+            Content = bodyContent
+        };
+
+        var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        return JsonConvert.DeserializeObject<TResponse>(content)!;
+    }
+
     protected async Task<TResponse> PostAsync<TRequest, TResponse>(
         string path,
         TRequest request,

--- a/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
@@ -3,7 +3,6 @@ using Feijuca.Auth.Http.BaseHttp;
 using Feijuca.Auth.Http.Requests;
 using Feijuca.Auth.Http.Responses;
 using Feijuca.Auth.Models;
-using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;

--- a/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
@@ -3,6 +3,7 @@ using Feijuca.Auth.Http.BaseHttp;
 using Feijuca.Auth.Http.Requests;
 using Feijuca.Auth.Http.Responses;
 using Feijuca.Auth.Models;
+using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -78,6 +79,18 @@ namespace Feijuca.Auth.Http.Client
             return Result<IEnumerable<GroupResponse>>.Success(result);
         }
 
+        public async Task<Result> RemoveUsersFromGroupAsync(RemoveUserFromGroupRequest removeUserFromGroupRequest, CancellationToken cancellationToken)
+        {
+            var result = await DeleteAsync<RemoveUserFromGroupRequest, bool>("groups/users", removeUserFromGroupRequest, cancellationToken);
+
+            if (!result)
+            {
+                return Result.Failure(FeijucaErrors.RemoveUsersFromGroupError);
+            }
+
+            return Result.Success();
+        }
+
         public async Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken)
         {
             var result = await GetAsync<PagedResult<UserGroupResponse>>($"groups/users?groupId={groupId}", jwtToken, cancellationToken);
@@ -100,6 +113,18 @@ namespace Feijuca.Auth.Http.Client
             }
 
             return Result<IEnumerable<RealmResponse>>.Success(result);
+        }
+
+        public async Task<Result> CreateRealmAsync(IEnumerable<AddRealmRequest> AddRealmsRequest, CancellationToken cancellationToken)
+        {
+            var result = await _httpClient.PostAsJsonAsync("realms", AddRealmsRequest, cancellationToken);
+
+            if (!result.IsSuccessStatusCode)
+            {
+                return Result.Failure(FeijucaErrors.CreateRealmError);
+            }
+
+            return Result.Success();
         }
 
         public async Task<Result> ReplicateRealmAsync(ReplicateRealmRequest request, CancellationToken cancellationToken)

--- a/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
@@ -11,11 +11,13 @@ public interface IFeijucaAuthClient
     Task<Result<UserResponse>> GetUserAsync(string tenant, string userame, string jwtToken, CancellationToken cancellationToken);
     Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken);
     Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken);
+    Task<Result> RemoveUsersFromGroupAsync(Guid UserId, Guid GroupId, CancellationToken cancellationToken);
     Task<Result<IEnumerable<RealmResponse>>> GetRealmsAsync(string jwtToken, CancellationToken cancellationToken);
     Task<Result<string>> CreateGroupAsync(CreateGroupRequest request, CancellationToken cancellationToken);
     Task<Result<Guid>> CreateUserAsync(CreateUserRequest request, string tenant, CancellationToken cancellationToken);
     Task<Result> AddUserToGroupAsync(AddUserToGroupRequest request, CancellationToken cancellationToken);
     Task<Result> ReplicateRealmAsync(ReplicateRealmRequest request, CancellationToken cancellationToken);
+    Task<Result> CreateRealmAsync(IEnumerable<AddRealmRequest> AddRealmsRequest, CancellationToken cancellationToken);
     Task<Result> UpdateGroupNameAsync(Guid groupId, UpdateGroupNameRequest request, CancellationToken cancellationToken);
     void SetToken(string token);
 }

--- a/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
@@ -11,7 +11,7 @@ public interface IFeijucaAuthClient
     Task<Result<UserResponse>> GetUserAsync(string tenant, string userame, string jwtToken, CancellationToken cancellationToken);
     Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken);
     Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken);
-    Task<Result> RemoveUsersFromGroupAsync(Guid UserId, Guid GroupId, CancellationToken cancellationToken);
+    Task<Result> RemoveUsersFromGroupAsync(RemoveUserFromGroupRequest removeUserFromGroupRequest, CancellationToken cancellationToken);
     Task<Result<IEnumerable<RealmResponse>>> GetRealmsAsync(string jwtToken, CancellationToken cancellationToken);
     Task<Result<string>> CreateGroupAsync(CreateGroupRequest request, CancellationToken cancellationToken);
     Task<Result<Guid>> CreateUserAsync(CreateUserRequest request, string tenant, CancellationToken cancellationToken);

--- a/src/NuGet/Feijuca.Auth/Http/Requests/AddRealmRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/AddRealmRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace Feijuca.Auth.Http.Requests;
+
+public record AddRealmRequest(string Name, string Description);

--- a/src/NuGet/Feijuca.Auth/Http/Requests/RemoveUserFromGroupRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/RemoveUserFromGroupRequest.cs
@@ -1,0 +1,3 @@
+﻿namespace Feijuca.Auth.Http.Requests;
+
+public record RemoveUserFromGroupRequest(Guid UserId, Guid GroupId);


### PR DESCRIPTION
Summary

This PR adds support for DELETE requests with request bodies and exposes two new Count endpoints.

Changes

Added DeleteAsync<TRequest, TResponse> to the HTTP client.

Exposed two new Count endpoints.

Included error handling for the new operations.