### PR TITLE
refactor: centralize token and header configuration in FeijucaAuthClient

### DIFF
--- a/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/FeijucaAuthClient.cs
@@ -64,11 +64,9 @@ namespace Feijuca.Auth.Http.Client
             return Result<PagedResult<UserResponse>>.Success(result);
         }
 
-        public async Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken)
+        public async Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(CancellationToken cancellationToken)
         {
-            IncludeTenantHeader(tenant);
-
-            var result = await GetAsync<IEnumerable<GroupResponse>>("groups", jwtToken, cancellationToken);
+            var result = await GetAsync<IEnumerable<GroupResponse>>("groups", cancellationToken);
 
             if (!result.Any())
             {
@@ -203,6 +201,22 @@ namespace Feijuca.Auth.Http.Client
             if(!string.IsNullOrEmpty(jwtToken))
             {
                 _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwtToken);
+            }
+        }
+
+        /// <summary>
+        /// Sets the headers used in requests.
+        /// </summary>
+        /// <param name="headers">Headers to be included in the requests.</param>
+        public void SetHeaders(params (string Name, string Value)[] headers)
+        {
+            foreach (var (name, value) in headers)
+            {
+                if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value))
+                {
+                    _httpClient.DefaultRequestHeaders.Remove(name);
+                    _httpClient.DefaultRequestHeaders.Add(name, value);
+                }
             }
         }
 

--- a/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Client/IFeijucaAuthClient.cs
@@ -9,7 +9,7 @@ public interface IFeijucaAuthClient
     Task<Result<TokenDetailsResponse>> AuthenticateUserAsync(string tenant, string username, string password, CancellationToken cancellationToken);
     Task<Result<PagedResult<UserResponse>>> GetUsersAsync(string tenant, int maxUsers, string jwtToken, CancellationToken cancellationToken);
     Task<Result<UserResponse>> GetUserAsync(string tenant, string userame, string jwtToken, CancellationToken cancellationToken);
-    Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(string tenant, string jwtToken, CancellationToken cancellationToken);
+    Task<Result<IEnumerable<GroupResponse>>> GetGroupsAsync(CancellationToken cancellationToken);
     Task<Result<PagedResult<UserGroupResponse>>> GetGroupUsersAsync(string groupId, string jwtToken, CancellationToken cancellationToken);
     Task<Result<IEnumerable<RealmResponse>>> GetRealmsAsync(string jwtToken, CancellationToken cancellationToken);
     Task<Result<string>> CreateGroupAsync(CreateGroupRequest request, CancellationToken cancellationToken);
@@ -17,4 +17,5 @@ public interface IFeijucaAuthClient
     Task<Result> AddUserToGroupAsync(AddUserToGroupRequest request, CancellationToken cancellationToken);
     Task<Result> UpdateGroupNameAsync(Guid groupId, UpdateGroupNameRequest request, CancellationToken cancellationToken);
     void SetToken(string token);
+    void SetHeaders(params (string Name, string Value)[] headers);
 }


### PR DESCRIPTION
## Refatoração do `FeijucaAuthClient` para centralizar a configuração de autenticação e headers das requisições.

### Alterações

* Removidos o token e o tenant dos parâmetros do `GetGroupsAsync`.
* Adicionado o método `SetHeaders` para configurar headers adicionais.