### PR TITLE
Adiciona IncludeGroups em ReplicationConfigurationRequest

### DIFF
--- a/src/NuGet/Feijuca.Auth/Http/Requests/ReplicationConfigurationRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/ReplicationConfigurationRequest.cs
@@ -5,5 +5,6 @@ public record ReplicationConfigurationRequest(
     bool IncludeClientRoles,
     bool IncludeClientScopes,
     bool CreateAdminGroupWithAllRulesAssociated,
+    bool IncludeGroups,
     LoginUserRequest AdminUser
     );


### PR DESCRIPTION
Agora é possível incluir grupos na configuração de replicação através da nova propriedade IncludeGroups adicionada ao record ReplicationConfigurationRequest.