### PR TITLE
feat: replicate groups and permissions during realm replication

### DIFF
--- a/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
@@ -101,12 +101,14 @@ namespace Feijuca.Auth.Application.Queries.Realm
 
             if (request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups ?? false)
             {
-                var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data;
+                var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data
+                    .Where(x => x.Name != Constants.AdminGroupName);
 
                 foreach (var group in originGroups)
                 {
-                    var groupCreateId = await groupRepository.CreateAsync(group.Name, targetTenant, [], cancellationToken);
                     var roulesGroup = (await groupRolesRepository.GetGroupRolesAsync(group.Id, cancellationToken)).Data;
+                    var groupCreateId = await groupRepository.CreateAsync(group.Name, targetTenant, [], cancellationToken);
+                    
 
                     foreach (var role in roulesGroup)
                     {

--- a/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
@@ -99,6 +99,22 @@ namespace Feijuca.Auth.Application.Queries.Realm
                 await clientScopesRepository.AddUserPropertyMapperAsync(clientScopeProfile.Id!, "tenant", "tenant", targetTenant, cancellationToken);
             }
 
+            if (request.ReplicateRealmRequest.ReplicationConfigurationRequest.IncludeGroups)
+            {
+                var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data;
+
+                foreach (var group in originGroups)
+                {
+                    var groupCreateId = await groupRepository.CreateAsync(group.Name, targetTenant, [], cancellationToken);
+                    var roulesGroup = (await groupRolesRepository.GetGroupRolesAsync(group.Id, cancellationToken)).Data;
+
+                    foreach (var role in roulesGroup)
+                    {
+                        await AssociateClientRulesToTheGroupAsync(targetTenant, groupCreateId.Data, role.Client, cancellationToken);
+                    }
+                }
+            }
+
             return Result<bool>.Success(true);
         }
 

--- a/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
@@ -99,7 +99,7 @@ namespace Feijuca.Auth.Application.Queries.Realm
                 await clientScopesRepository.AddUserPropertyMapperAsync(clientScopeProfile.Id!, "tenant", "tenant", targetTenant, cancellationToken);
             }
 
-            if (request.ReplicateRealmRequest.ReplicationConfigurationRequest.IncludeGroups)
+            if (request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups ?? false)
             {
                 var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data;
 

--- a/src/Api/Feijuca.Auth.Common/Feijuca.Auth.Common.csproj
+++ b/src/Api/Feijuca.Auth.Common/Feijuca.Auth.Common.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="4.0.0" />
-    <PackageReference Include="Feijuca.Auth" Version="1.82.1" />
+    <PackageReference Include="Feijuca.Auth" Version="1.83.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Api/Feijuca.Auth.Domain/Interfaces/IGroupRolesRepository.cs
+++ b/src/Api/Feijuca.Auth.Domain/Interfaces/IGroupRolesRepository.cs
@@ -10,3 +10,4 @@ namespace Feijuca.Auth.Domain.Interfaces
         Task<Result> RemoveRoleFromGroupAsync(string clientId, string groupId, Guid roleId, string roleName, CancellationToken cancellationToken);
     }
 }
+ 


### PR DESCRIPTION
What was implemented

Added support to replicate groups during realm replication when IncludeGroups is enabled.

Groups from the source realm are created in the destination realm with their respective role permissions.

Improved null safety in ReplicateRealmCommandHandler to prevent NullReferenceException when reading IncludeGroups.

Updated Feijuca.Auth dependency from 1.82.1 to 1.83.0.

Minor formatting adjustment in IGroupRolesRepository (no functional impact).