### PR TITLE
feat: Alterar IncludeGroups para string[] em ReplicationConfig

### DIFF
--- a/src/NuGet/Feijuca.Auth/Http/Requests/ReplicationConfigurationRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/ReplicationConfigurationRequest.cs
@@ -5,6 +5,6 @@ public record ReplicationConfigurationRequest(
     bool IncludeClientRoles,
     bool IncludeClientScopes,
     bool CreateAdminGroupWithAllRulesAssociated,
-    bool IncludeGroups,
+    string[] IncludeGroups,
     LoginUserRequest AdminUser
     );

--- a/src/NuGet/Feijuca.Auth/Http/Requests/ReplicationConfigurationRequest.cs
+++ b/src/NuGet/Feijuca.Auth/Http/Requests/ReplicationConfigurationRequest.cs
@@ -5,6 +5,6 @@ public record ReplicationConfigurationRequest(
     bool IncludeClientRoles,
     bool IncludeClientScopes,
     bool CreateAdminGroupWithAllRulesAssociated,
-    string[] IncludeGroups,
+    IEnumerable<string> IncludeGroups,
     LoginUserRequest AdminUser
     );


### PR DESCRIPTION
O campo IncludeGroups em ReplicationConfigurationRequest foi alterado de booleano para array de strings, permitindo especificar múltiplos grupos ao invés de apenas indicar inclusão ou não.