### PR TITLE
feat: Restringe replicação a grupos em IncludeGroups e atualiza Feiju…

### DIFF
--- a/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
@@ -99,10 +99,11 @@ namespace Feijuca.Auth.Application.Queries.Realm
                 await clientScopesRepository.AddUserPropertyMapperAsync(clientScopeProfile.Id!, "tenant", "tenant", targetTenant, cancellationToken);
             }
 
-            if (request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups ?? false)
+            if (request.ReplicateRealmRequest?.ReplicationConfigurationRequest?.IncludeGroups.Any() ?? false)
             {
                 var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data
-                    .Where(x => x.Name != Constants.AdminGroupName);
+                    .Where(x => x.Name != Constants.AdminGroupName)
+                    .Where(x => request.ReplicateRealmRequest.ReplicationConfigurationRequest.IncludeGroups.Contains(x.Name));
 
                 var clientsDestination = (await clientRepository.GetClientsAsync(targetTenant, cancellationToken)).Data;
 

--- a/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
@@ -99,11 +99,17 @@ namespace Feijuca.Auth.Application.Queries.Realm
                 await clientScopesRepository.AddUserPropertyMapperAsync(clientScopeProfile.Id!, "tenant", "tenant", targetTenant, cancellationToken);
             }
 
-            if (request.ReplicateRealmRequest?.ReplicationConfigurationRequest?.IncludeGroups.Any() ?? false)
+            if (true)
             {
                 var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data
-                    .Where(x => x.Name != Constants.AdminGroupName)
-                    .Where(x => request.ReplicateRealmRequest.ReplicationConfigurationRequest.IncludeGroups.Contains(x.Name));
+                    .Where(x => x.Name != Constants.AdminGroupName);
+
+                var listGroups = request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups;
+
+                if (listGroups?.Any() ?? false)
+                {
+                    originGroups = originGroups.Where(x => listGroups.Contains(x.Name));
+                }
 
                 var clientsDestination = (await clientRepository.GetClientsAsync(targetTenant, cancellationToken)).Data;
 

--- a/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
+++ b/src/Api/Feijuca.Auth.Application/Queries/Realm/ReplicateRealmCommandHandler.cs
@@ -99,14 +99,14 @@ namespace Feijuca.Auth.Application.Queries.Realm
                 await clientScopesRepository.AddUserPropertyMapperAsync(clientScopeProfile.Id!, "tenant", "tenant", targetTenant, cancellationToken);
             }
 
-            if (true)
+            if (request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups != null)
             {
                 var originGroups = (await groupRepository.GetAllAsync(cancellationToken)).Data
                     .Where(x => x.Name != Constants.AdminGroupName);
 
-                var listGroups = request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups;
+                var listGroups = request.ReplicateRealmRequest?.ReplicationConfigurationRequest.IncludeGroups!;
 
-                if (listGroups?.Any() ?? false)
+                if (listGroups.Any())
                 {
                     originGroups = originGroups.Where(x => listGroups.Contains(x.Name));
                 }

--- a/src/Api/Feijuca.Auth.Common/Feijuca.Auth.Common.csproj
+++ b/src/Api/Feijuca.Auth.Common/Feijuca.Auth.Common.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="4.0.0" />
-    <PackageReference Include="Feijuca.Auth" Version="1.83.0" />
+    <PackageReference Include="Feijuca.Auth" Version="1.84.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
A replicação de grupos agora ocorre apenas para os grupos explicitamente listados em IncludeGroups, ao invés de replicar todos quando IncludeGroups é verdadeiro. A lógica foi ajustada para filtrar os grupos de origem conforme IncludeGroups. Atualizada a dependência Feijuca.Auth de 1.83.0 para 1.84.0 no projeto.